### PR TITLE
v0.1.2: add logs, bugfix, more tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,6 @@ install:
 	python3 -m pip install .
 
 docs: install
-	python3 -m pip install pdoc3
+	python3 -m pip list --format=freeze | cut -d"=" -f1 | grep -x 'pdoc3' -q || python3 -m pip install pdoc3
 	rm -rf ./docs
 	pdoc3 -o ./docs sqlite_backup

--- a/README.md
+++ b/README.md
@@ -39,22 +39,44 @@ Usage: sqlite_backup [OPTIONS] SOURCE_DATABASE DESTINATION
   possibly overwriting old data)
 
 Options:
+  --debug                         Increase log verbosity  [default: False]
   --wal-checkpoint / --no-wal-checkpoint
                                   After writing to the destination, run a
                                   checkpoint to truncate the WAL to zero bytes
-  --copy-use-tempdir / --copy-no-tempdir
+                                  [default: wal-checkpoint]
+  --copy-use-tempdir / --no-copy-use-tempdir
                                   Copy the source database files to a
                                   temporary directory, then connect to the
-                                  copied files
+                                  copied files  [default: copy-use-tempdir]
   --copy-retry INTEGER            If the files change while copying to the
-                                  temporary directory, retry <n> many times
+                                  temporary directory, retry <n> times
+                                  [default: 100]
   --copy-retry-strict / --no-copy-retry-strict
                                   Throws an error if this fails to safely copy
                                   the database files --copy-retry times
-  --help                          Show this message and exit.
+                                  [default: copy-retry-strict]
+  --help                          Show this message and exit.  [default:
+                                  False]
 ```
 
 For usage in python, use the `sqlite_backup` function, see the [docs](./docs/sqlite_backup/core.md)
+
+If you plan on reading from these backed up databases (and you're not planning on modifying these at all), I would recommend using the [`immutable` flag](https://www.sqlite.org/uri.html#uriimmutable) when connecting to the database. In python, like:
+
+```python
+import sqlite3
+from typing import Iterator
+
+def sqlite_connect_immutable(database: str) -> Iterator[sqlite3.Connection]:
+    try:
+        with sqlite3.connect(f"file:{database}?immutable=1", uri=True) as conn:
+            yield conn
+    finally:
+        conn.close()
+
+with sqlite_connect_immutable("/path/to/database") as conn:
+    conn.execute("...")
+```
 
 ### Tests
 

--- a/README.md
+++ b/README.md
@@ -61,20 +61,21 @@ Options:
 
 For usage in python, use the `sqlite_backup` function, see the [docs](./docs/sqlite_backup/core.md)
 
-If you plan on reading from these backed up databases (and you're not planning on modifying these at all), I would recommend using the [`immutable` flag](https://www.sqlite.org/uri.html#uriimmutable) when connecting to the database. In python, like:
+If you plan on reading from these backed up databases (and you're not planning on modifying these at all), I would recommend using the [`mode=ro`](https://www.sqlite.org/uri.html#urimode) (readonly) or [`immutable` flag](https://www.sqlite.org/uri.html#uriimmutable) flags when connecting to the database. In python, like:
 
 ```python
 import sqlite3
 from typing import Iterator
 
-def sqlite_connect_immutable(database: str) -> Iterator[sqlite3.Connection]:
+def sqlite_connect(database: str) -> Iterator[sqlite3.Connection]:
     try:
-        with sqlite3.connect(f"file:{database}?immutable=1", uri=True) as conn:
+        # or for immutable, f"file:{database}?immutable=1"
+        with sqlite3.connect(f"file:{database}?mode=ro", uri=True) as conn:
             yield conn
     finally:
         conn.close()
 
-with sqlite_connect_immutable("/path/to/database") as conn:
+with sqlite_connect("/path/to/database") as conn:
     conn.execute("...")
 ```
 

--- a/docs/sqlite_backup/core.md
+++ b/docs/sqlite_backup/core.md
@@ -14,7 +14,7 @@ Functions
     If the file did change (before the final copy, which succeeded) while we were copying it, this returns False
 
     
-`copy_all_files(source_files: List[pathlib.Path], temporary_dest: pathlib.Path, copy_function: Callable[[str, str], bool], retry: int = 100) ‑> bool`
+`copy_all_files(source_files: List[pathlib.Path], temporary_dest: pathlib.Path, copy_function: Callable[[str, str], bool], retry: int) ‑> bool`
 :   Copy all files from source to directory
     This retries (up to 'retry' count) if any of the files change while any of the copies were copying
     
@@ -30,7 +30,7 @@ Functions
 :   List any of the temporary database files (and the database itself)
 
     
-`sqlite_backup(source: Union[str, pathlib.Path], destination: Union[str, pathlib.Path, ForwardRef(None)] = None, *, wal_checkpoint: bool = True, copy_use_tempdir: bool = True, copy_retry: int = 100, copy_retry_strict: bool = False, sqlite_connect_kwargs: Optional[Dict[str, Any]] = None, sqlite_backup_kwargs: Optional[Dict[str, Any]] = None, copy_function: Optional[Callable[[str, str], bool]] = None) ‑> Optional[sqlite3.Connection]`
+`sqlite_backup(source: Union[str, pathlib.Path], destination: Union[str, pathlib.Path, ForwardRef(None)] = None, *, wal_checkpoint: bool = True, copy_use_tempdir: bool = True, copy_retry: int = 100, copy_retry_strict: bool = True, sqlite_connect_kwargs: Optional[Dict[str, Any]] = None, sqlite_backup_kwargs: Optional[Dict[str, Any]] = None, copy_function: Optional[Callable[[str, str], bool]] = None) ‑> Optional[sqlite3.Connection]`
 :   'Snapshots' the source database and opens by making a deep copy of it, including journal/WAL files
     
     If you don't specify a 'destination', this copies the database

--- a/docs/sqlite_backup/index.md
+++ b/docs/sqlite_backup/index.md
@@ -4,3 +4,4 @@ Module sqlite_backup
 Sub-modules
 -----------
 * sqlite_backup.core
+* sqlite_backup.log

--- a/docs/sqlite_backup/log.md
+++ b/docs/sqlite_backup/log.md
@@ -1,0 +1,10 @@
+Module sqlite_backup.log
+========================
+Setup logging for this module
+
+Functions
+---------
+
+    
+`setup(level: Optional[int] = None) ‑> logging.Logger`
+:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 click>=7.0
+logzero

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ reqs = Path("requirements.txt").read_text().strip().splitlines()
 pkg = "sqlite_backup"
 setup(
     name=pkg,
-    version="0.1.1",
+    version="0.1.2",
     url="https://github.com/seanbreckenridge/sqlite_backup",
     author="Sean Breckenridge",
     author_email="seanbrecke@gmail.com",

--- a/sqlite_backup/log.py
+++ b/sqlite_backup/log.py
@@ -1,0 +1,27 @@
+"""
+Setup logging for this module
+"""
+
+import os
+import logging
+
+from typing import Optional
+
+from logzero import setup_logger  # type: ignore[import]
+
+DEFAULT_LEVEL = logging.WARNING
+
+# global access to the logger
+logger: logging.Logger
+
+
+# logzero handles adding handling/modifying levels fine
+# can be imported/configured multiple times
+def setup(level: Optional[int] = None) -> logging.Logger:
+    chosen_level = level or int(os.environ.get("SQLITE_BACKUP_LOGS", DEFAULT_LEVEL))
+    lgr: logging.Logger = setup_logger(name=__package__, level=chosen_level)
+    return lgr
+
+
+# runs the first time this file is run, setup can be imported/run multiple times in other places
+logger = setup()

--- a/tests/test_sqlite_backup.py
+++ b/tests/test_sqlite_backup.py
@@ -193,6 +193,14 @@ def test_copy_to_another_file(
         #
         # It does indeed seem to call 'sqlite3_close_v2'
         # https://github.com/python/cpython/blob/8fb36494501aad5b0c1d34311c9743c60bb9926c/Modules/_sqlite/connection.c#L340
+        #
+        # Perhaps; see https://www.sqlite.org/walformat.html
+        # When a database connection closes (via sqlite3_close() or sqlite3_close_v2()),
+        # an attempt is made to acquire SQLITE_LOCK_EXCLUSIVE
+        #
+        # Its not able to acquire a SQLITE_LOCK_EXCLUSIVE, so it doesn't truncate the WAL file?
+        # However, below in test_backup_with_checkpoint wal_checkpoint(TRUNCATE) should **block** till that happens
+        #
         # which reading some of the comments here, confirms the (incorrectly descrbied?) behaviour I see
         # https://github.com/groue/GRDB.swift/issues/418
         # https://github.com/groue/GRDB.swift/issues/739

--- a/tests/test_sqlite_backup.py
+++ b/tests/test_sqlite_backup.py
@@ -54,6 +54,9 @@ def sqlite_with_wal(
         wals = list(db.parent.glob("*-wal"))
         assert len(wals) == 1
 
+        # make sure -wal file is not empty
+        assert wals[0].stat().st_size > 0
+
         yield db
 
     conn.close()
@@ -273,6 +276,10 @@ def test_backup_with_checkpoint(
             Path(str(destination_database) + "-wal"),
         }
         assert set(destination_database.parent.iterdir()) == expected
+
+        # however, at least we can confirm the write ahead log is empty after a wal checkpoint
+        log_file = Path(str(destination_database) + "-wal")
+        assert log_file.stat().st_size == 0
 
     run_in_thread(_run)
 

--- a/tests/test_sqlite_backup.py
+++ b/tests/test_sqlite_backup.py
@@ -278,8 +278,9 @@ def test_backup_with_checkpoint(
         assert set(destination_database.parent.iterdir()) == expected
 
         # however, at least we can confirm the write ahead log is empty after a wal checkpoint
-        log_file = Path(str(destination_database) + "-wal")
-        assert log_file.stat().st_size == 0
+        wal = Path(str(destination_database) + "-wal")
+        assert wal.exists()
+        assert wal.stat().st_size == 0
 
     run_in_thread(_run)
 


### PR DESCRIPTION
- logs can be controlled with `SQLITE_BACKUP_LOGS` or `--debug` flag
- set `copy_retry_strict` to `True` by default
- bugfix: since testing for the `succeeded/failed` (whether the file copied) boolean was flipped, this was copying the file more times than necessary
- cover current `shm`/`wal` behavior in tests, lots of comments to describe current situation