### PR TITLE
check source != destination

### DIFF
--- a/docs/sqlite_backup/core.md
+++ b/docs/sqlite_backup/core.md
@@ -55,9 +55,13 @@ Functions
     
     'wal_checkpoint' runs a 'PRAGMA wal_checkpoint(TRUNCATE)' after it writes to
     the destination database, which truncates the write ahead log to 0 bytes.
-    This is to ensure that all data is contained in the single database file -
-    so all data is accessible even if this is opened in immutable mode in the future
-    https://www.sqlite.org/pragma.html#pragma_wal_checkpoint
+    Typically the WAL is removed when the database is closed, but particular builds of sqlite
+    or sqlite compiled with SQLITE_DBCONFIG_NO_CKPT_ON_CLOSE may prevent that --
+    so the checkpoint exists to ensure there are no temporary files leftover
+    
+    See:
+    https://sqlite.org/forum/forumpost/1fdfc1a0e7
+    https://www.sqlite.org/c3ref/c_dbconfig_enable_fkey.html
     
     if 'copy_use_tempdir' is False, that skips the copy, which increases the chance that this fails
     (if theres a lock (SQLITE_BUSY, SQLITE_LOCKED)) on the source database,

--- a/tests/test_sqlite_backup.py
+++ b/tests/test_sqlite_backup.py
@@ -1,7 +1,7 @@
 import shutil
 import sqlite3
 from pathlib import Path
-from typing import Generator
+from typing import Iterator, Any, Set
 
 import pytest
 
@@ -19,13 +19,30 @@ from sqlite_backup.core import (
 from . import run_in_thread
 
 
-# tmp_path is a pytest provided fixture
+# tmp_path is test-scoped, not function-scoped
+
+
+@pytest.fixture(scope="function")
+def tmp_path_f(
+    request: Any, tmp_path_factory: pytest.TempPathFactory
+) -> Iterator[Path]:
+    """
+    Create a new tempdir every time this runs
+    """
+    # request is a _pytest.fixture.SubRequest, function that called this
+    assert isinstance(request.function.__name__, str), str(request)
+    assert request.function.__name__.strip(), str(request)
+    yield tmp_path_factory.mktemp(request.function.__name__, numbered=True)
+
+
+def _list_files(p: Path) -> Set[Path]:
+    return {f for f in p.iterdir() if f.is_file()}
 
 
 @pytest.fixture()
 def sqlite_with_wal(
-    tmp_path: Path,
-) -> Generator[Path, None, None]:
+    tmp_path_f: Path,
+) -> Iterator[Path]:
     """
     In a temporary directory, create a database with a basic table
     insert 5 items into it and let sqlite3.connection close the connection
@@ -36,7 +53,8 @@ def sqlite_with_wal(
     are uncommitted
     See https://sqlite.org/wal.html
     """
-    db = tmp_path / "db.sqlite"
+    db = tmp_path_f / "sqlite_with_wal" / "db.sqlite"
+    db.parent.mkdir(exist_ok=False)
     # write a bit
     with sqlite3.connect(str(db)) as conn:
         conn.execute("CREATE TABLE testtable (col)")
@@ -77,14 +95,14 @@ def test_open_asis(sqlite_with_wal: Path, reraise: Reraise) -> None:
     run_in_thread(_run)
 
 
-def test_do_copy(sqlite_with_wal: Path, tmp_path: Path, reraise: Reraise) -> None:
+def test_do_copy(sqlite_with_wal: Path, tmp_path_f: Path, reraise: Reraise) -> None:
     """
     a copy of the database itself without the WAL can only read previously committed stuff
     """
 
     @reraise.wrap
     def _run() -> None:
-        cdb = Path(tmp_path) / "dbcopy.sqlite"
+        cdb = Path(tmp_path_f) / "dbcopy.sqlite"
         shutil.copy(sqlite_with_wal, cdb)
         with sqlite3.connect(cdb) as conn_copy:
             assert len(list(conn_copy.execute("SELECT * FROM testtable"))) == 5
@@ -163,7 +181,7 @@ def test_do_copy_and_open(sqlite_with_wal: Path, reraise: Reraise) -> None:
 
 
 def test_copy_to_another_file(
-    sqlite_with_wal: Path, reraise: Reraise, tmp_path: Path
+    sqlite_with_wal: Path, reraise: Reraise, tmp_path_f: Path
 ) -> None:
     """
     Copy from the sqlite_with_wal to another database file -- this
@@ -177,7 +195,7 @@ def test_copy_to_another_file(
 
     @reraise.wrap
     def _run() -> None:
-        destination_database = tmp_path / "db.sqlite"
+        destination_database = tmp_path_f / "db.sqlite"
         conn = sqlite_backup(
             sqlite_with_wal, destination_database, wal_checkpoint=False
         )
@@ -187,114 +205,45 @@ def test_copy_to_another_file(
             assert len(list(dest_conn.execute("SELECT * FROM testtable"))) == 10
         dest_conn.close()
 
-        # according to the docs, https://www.sqlite.org/walformat.html#file_lifecycles:
-        #
-        # If the last client using the database shuts down cleanly by calling
-        # sqlite3_close(), then a checkpoint is run automatically in order to transfer
-        # all information from the wal file over into the main database, and both the shm
-        # file and the wal file are unlinked
-        #
-        # It does indeed seem to call 'sqlite3_close_v2'
-        # https://github.com/python/cpython/blob/8fb36494501aad5b0c1d34311c9743c60bb9926c/Modules/_sqlite/connection.c#L340
-        #
-        # Perhaps; see https://www.sqlite.org/walformat.html
-        # When a database connection closes (via sqlite3_close() or sqlite3_close_v2()),
-        # an attempt is made to acquire SQLITE_LOCK_EXCLUSIVE
-        #
-        # Its not able to acquire a SQLITE_LOCK_EXCLUSIVE, so it doesn't truncate the WAL file?
-        #
-        # which reading some of the comments here, confirms the (incorrectly descrbied?) behaviour I see
-        # https://github.com/groue/GRDB.swift/issues/418
-        # https://github.com/groue/GRDB.swift/issues/739
-        #
-        # Also here, it seems that this issue was seemingly resolved by upgrading
-        # versions, but no particular commit/bugfix pointed to
-        # https://sqlite.org/forum/forumpost/1fdfc1a0e7
-        #
-        # It may depend on a compilation flag, https://www.sqlite.org/c3ref/c_dbconfig_enable_fkey.html
-        # SQLITE_DBCONFIG_NO_CKPT_ON_CLOSE (though that is disabled on my system)
-        # so its not a good idea to depend on the
-        # the fact that the -shm and -wal files "*wont*" be here:
-        # https://github.com/groue/GRDB.swift/issues/771#issuecomment-624479526
-        #
-        # from a user perspective (me manually testing this on databases), running the
-        # while wal_checkpoint=True, I've never seen the -wal/-shm files after
-        # the python process ends, so perhaps sqlite or python C code is keeping
-        # track of which databases have been connected to, and atexit they
-        # respect this behaviour? But I can't reproduce it here
-
-        # since we didn't run a wal checkpoint, the WAL at the destination still has data here --
-        # would suggest connection.backup corectly copies data from the source WAL to the target destination
-        wal = Path(str(destination_database) + "-wal")
-        assert wal.exists()
-        assert wal.stat().st_size > 0
-
-        # with all that in mind, lets just test against the current behaviour
-        # so if it changes we know it has
-
-        expected = {
-            destination_database,
-            Path(str(destination_database) + "-shm"),
-            Path(str(destination_database) + "-wal"),
-        }
-        assert set(destination_database.parent.iterdir()) == expected
+        # make sure no -wal/-shm files exist
+        assert _list_files(tmp_path_f) == {destination_database}
 
     run_in_thread(_run)
 
 
 def test_backup_with_checkpoint(
-    sqlite_with_wal: Path, reraise: Reraise, tmp_path: Path
+    sqlite_with_wal: Path, reraise: Reraise, tmp_path_f: Path
 ) -> None:
     """
-    Copy from the sqlite_with_wal to another database file, then
-    run a WAL checkpoint to absorb any temporary files
+    Copy from the sqlite_with_wal to another database file
+    run a wal_checkpoint to make sure that works
 
     test this worked by opening it in immutable mode
     """
 
     @reraise.wrap
     def _run() -> None:
-        destination_database = tmp_path / "db.sqlite"
+        destination_database = tmp_path_f / "db.sqlite"
         conn = sqlite_backup(sqlite_with_wal, destination_database, wal_checkpoint=True)
         assert conn is None  # the database connection is closed
+
+        # no -wal/-shm files exist after the connection.backup
+        assert _list_files(tmp_path_f) == {destination_database}
+
         # should be able to read all data in immutable mode
         with sqlite_connect_immutable(destination_database) as dest_conn:
             assert len(list(dest_conn.execute("SELECT * FROM testtable"))) == 10
         dest_conn.close()
 
-        # just like above, even if reading in immutable we still have -shm/-wal files here
-        #
-        # the theories I have are therefore:
-        # 1) either connection.backup is copying the -shm/-wal files (which is understandable)
-        #    and even running the wal_checkpoint(TRUNCATE) doesn't remove the files till after the process
-        #    ends, even though we've already closed the connection. However, running the wal_checkpoint
-        #    does appear to successfully truncate the WAL to 0 bytes, the file just
-        #    isn't deleted when the connection is closed, irrespective of whether or
-        #    not we ran a checkpoint
-        # 2) immutable is creating files, which shoud never be happening according to the docs:
-        #    https://www.sqlite.org/uri.html#uriimmutable
-        #
-        # Disregarding all the confusion above, I don't think this interferes with how a user
-        # would use this. Even while opening in immutable (which should not pick up stuff from the -wal,
-        # as tested by test_do_immutable above), this still returns all 10 rows, not just 5
-
-        expected = {
-            destination_database,
-            Path(str(destination_database) + "-shm"),
-            Path(str(destination_database) + "-wal"),
-        }
-        assert set(destination_database.parent.iterdir()) == expected
-
-        # however, at least we can confirm the write ahead log is empty after a wal checkpoint
-        wal = Path(str(destination_database) + "-wal")
-        assert wal.exists()
-        assert wal.stat().st_size == 0
+        # no -wal/-shm files exist after opening in immutable, since
+        # it acts as if the data is on a read-only volume
+        assert _list_files(tmp_path_f) == {destination_database}
 
     run_in_thread(_run)
 
 
 def test_backup_without_checkpoint(
-    sqlite_with_wal: Path, reraise: Reraise, tmp_path: Path
+    sqlite_with_wal: Path, reraise: Reraise, tmp_path_f: Path
 ) -> None:
     """
     similar to test_copy_vacuum, if backup is run without a wal_checkpoint,
@@ -303,31 +252,36 @@ def test_backup_without_checkpoint(
 
     @reraise.wrap
     def _run() -> None:
-        destination_database = tmp_path / "db.sqlite"
+        destination_database = tmp_path_f / "db.sqlite"
         conn = sqlite_backup(
             sqlite_with_wal, destination_database, wal_checkpoint=False
         )
         assert conn is None  # the database connection is closed
-        # this has 5 and not 10, since immutable reads nothing from the copied
-        # -wal file which was not added to the main database file
+
+        # even without a checkpoint, should be no WAL in destination
+        assert _list_files(tmp_path_f) == {destination_database}
+
+        # both immutable and regular connections should read all the data
         with sqlite_connect_immutable(destination_database) as imm:
-            assert len(list(imm.execute("SELECT * FROM testtable"))) == 5
+            assert len(list(imm.execute("SELECT * FROM testtable"))) == 10
         imm.close()
 
-        # however, opening it without immutable should still pick up data in the WAL
         with sqlite3.connect(destination_database) as reg_conn:
             assert len(list(reg_conn.execute("SELECT * FROM testtable"))) == 10
         reg_conn.close()
 
+        # no -wal/-shm files should exist, after closing the reg_conn connection
+        assert _list_files(tmp_path_f) == {destination_database}
+
     run_in_thread(_run)
 
 
-def test_database_doesnt_exist(tmp_path: Path, reraise: Reraise) -> None:
+def test_database_doesnt_exist(tmp_path_f: Path, reraise: Reraise) -> None:
     """
     basic test to make sure sqlite_backup fails if db doesnt exist
     """
 
-    db = str(tmp_path / "db.sqlite")
+    db = str(tmp_path_f / "db.sqlite")
 
     def _run() -> None:
         with reraise:
@@ -367,3 +321,22 @@ def test_copy_retry_strict(sqlite_with_wal: Path, reraise: Reraise) -> None:
         "this failed to copy all files without any of them changing 100 times"
         in str(err)
     )
+
+
+def test_copy_different_source_and_dest(
+    sqlite_with_wal: Path, reraise: Reraise
+) -> None:
+    """
+    test to make sure if source == destination, that throws an error
+    """
+
+    def _run() -> None:
+        with reraise:
+            sqlite_backup(sqlite_with_wal, sqlite_with_wal)
+
+    run_in_thread(_run, allow_unwrapped=True)
+
+    err = reraise.reset()
+    assert isinstance(err, ValueError)
+    assert "'source' and 'destination'" in str(err)
+    assert "can't be the same" in str(err)


### PR DESCRIPTION
make sure source != destination, when copying
to a file. This exposed some problems with the tests
which could then be fixed; was using a pytest
test-scoped fixture instead of a function-scoped
