### PR TITLE
workaround for empty wal/shm turds on some macos systems

### DIFF
--- a/sqlite_backup/core.py
+++ b/sqlite_backup/core.py
@@ -243,6 +243,10 @@ def sqlite_backup(
             f"Running backup, from '{copy_from}' to '{destination or 'memory'}'"
         )
         with sqlite3.connect(copy_from, **sqlite_connect_kwargs) as conn:
+            if copy_use_tempdir:
+                # workaround for leftover wal/shm files on some macos systems
+                # see https://github.com/seanbreckenridge/sqlite_backup/issues/9
+                conn.execute('PRAGMA journal_mode=DELETE')
             conn.backup(target_connection, **sqlite_backup_kwargs)
 
         if destination is not None and wal_checkpoint:


### PR DESCRIPTION
Sadly this doesn't happen on github actions (perhaps because of different macos version), so can't cover with a test.

Most likely caused by a different default for SQLITE_FCNTL_PERSIST_WAL flag.

More context/discussion here:
https://github.com/seanbreckenridge/sqlite_backup/issues/9